### PR TITLE
new cron commands, improve syntax

### DIFF
--- a/update.js
+++ b/update.js
@@ -2,4 +2,6 @@ const proc = require('child_process');
 
 const isWindows = process.platform === 'win32';
 
-proc.spawnSync('npm', ['install'], {cwd:__dirname, env:process.env, stdio:'ignore', shell: isWindows || undefined});
+proc.spawnSync('npm', ['install'], {
+  cwd: __dirname, env: process.env, stdio: 'ignore', shell: isWindows || undefined,
+});


### PR DESCRIPTION
- Add a few new cron commands, take cron out of beta
- Clean up and improve help for commands
- Improve syntax
  - `aka taas` instead of `aka taas:tests`
  - `aka taas:config` instead of `aka taas:tests:config`
  - etc.
- Use positional arguments instead of options as much as possible
  - `aka taas:update test prop value` instead of `aka taas:tests:update test -p prop -v value`