### PR TITLE
COBRA-3718: Released hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -523,7 +523,7 @@ async function newRegister(appkit, args) {
   let pipelineStages;
   let pipelines;
   let overrideButWantedDefaultCommand = false;
-  let releasedHookEndpointExists;
+  let releasedHookEndpointExists = true;
 
   // Validator functions for user prompts
   const isRequired = input => (input.length > 0 ? true : 'Required Field');
@@ -610,11 +610,13 @@ async function newRegister(appkit, args) {
     }, []);
     pipelines.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 
+    // Ping /v1/releasedhook endpoint to see if it exists
     try {
       await appkit.http.post('', `${DIAGNOSTICS_API_URL}/v1/releasedhook`, plainType);
-      releasedHookEndpointExists = true;
     } catch (err) {
-      releasedHookEndpointExists = false;
+      if (err.code === 404) {
+        releasedHookEndpointExists = false;
+      }
     }
   } catch (err) {
     appkit.terminal.error(parseError(err));

--- a/index.js
+++ b/index.js
@@ -1008,7 +1008,7 @@ async function list(appkit) {
   try {
     const tests = await appkit.http.get(`${DIAGNOSTICS_API_URL}/v1/diagnostics?simple=true`, jsonType);
     if (!tests || tests.length === 0) {
-      appkit.terminal.error(appkit.terminal.markdown('No tests found. Register a test with ^^aka taas:tests:register^^'));
+      appkit.terminal.error(appkit.terminal.markdown('No tests found. Register a test with ^^aka taas:register^^'));
       return;
     }
     appkit.terminal.table(tests.map(test => ({

--- a/index.js
+++ b/index.js
@@ -523,7 +523,7 @@ async function newRegister(appkit, args) {
   let pipelineStages;
   let pipelines;
   let overrideButWantedDefaultCommand = false;
-  let hasReleasedHook;
+  let releasedHookEndpointExists;
 
   // Validator functions for user prompts
   const isRequired = input => (input.length > 0 ? true : 'Required Field');
@@ -612,9 +612,9 @@ async function newRegister(appkit, args) {
 
     try {
       await appkit.http.post('', `${DIAGNOSTICS_API_URL}/v1/releasedhook`, plainType);
-      hasReleasedHook = true;
+      releasedHookEndpointExists = true;
     } catch (err) {
-      hasReleasedHook = false;
+      releasedHookEndpointExists = false;
     }
   } catch (err) {
     appkit.terminal.error(parseError(err));
@@ -731,7 +731,7 @@ async function newRegister(appkit, args) {
       name: 'startDelay',
       type: 'number',
       message: 'Start Delay:',
-      when: !hasReleasedHook,
+      when: !releasedHookEndpointExists,
       validate: isInteger,
     },
     {
@@ -767,7 +767,7 @@ async function newRegister(appkit, args) {
     const diagnostic = {
       app: answers.app.split('-')[0],
       space: answers.app.split('-').slice(1).join('-'),
-      action: hasReleasedHook ? 'released' : 'release',
+      action: releasedHookEndpointExists ? 'released' : 'release',
       result: 'succeeded',
       job: answers.job,
       jobspace: answers.jobSpace,

--- a/index.js
+++ b/index.js
@@ -426,7 +426,7 @@ async function trigger(appkit, args) {
       release: { result, id: releases.length > 0 ? releases.pop().id : '' },
       build: { id: builds.length > 0 ? builds.pop().id : '' },
     };
-    await appkit.api.post(JSON.stringify(hook), `${DIAGNOSTICS_API_URL}/v1/releasehook`);
+    await appkit.api.post(JSON.stringify(hook), `${DIAGNOSTICS_API_URL}/v1/${action}hook`);
     console.log(appkit.terminal.markdown('^^ run initiated ^^'));
   } catch (err) {
     appkit.terminal.error(parseError(err));
@@ -720,12 +720,6 @@ async function newRegister(appkit, args) {
       validate: isInteger,
     },
     {
-      name: 'startDelay',
-      type: 'number',
-      message: 'Start Delay:',
-      validate: isInteger,
-    },
-    {
       name: 'slackChannel',
       type: 'input',
       message: 'Slack Channel (no leading #):',
@@ -758,7 +752,7 @@ async function newRegister(appkit, args) {
     const diagnostic = {
       app: answers.app.split('-')[0],
       space: answers.app.split('-').slice(1).join('-'),
-      action: 'release',
+      action: 'released',
       result: 'succeeded',
       job: answers.job,
       jobspace: answers.jobSpace,
@@ -768,7 +762,7 @@ async function newRegister(appkit, args) {
       transitionfrom: answers.autoPromote ? answers.transitionFrom.replace(' ', '') : 'manual',
       transitionto: answers.autoPromote ? answers.transitionTo.replace(' ', '') : 'manual',
       timeout: answers.timeout,
-      startdelay: answers.startDelay,
+      startdelay: 0,
       slackchannel: answers.slackChannel,
       testpreviews: answers.testPreviews,
       webhookurls: answers.webhookURLs,


### PR DESCRIPTION
Register new tests using the `released` hook, rather than the `release` hook.